### PR TITLE
Add status LED

### DIFF
--- a/ESPHome/hunter-roam-alt.yaml
+++ b/ESPHome/hunter-roam-alt.yaml
@@ -37,6 +37,11 @@ wifi:
     ssid: "HunterRoam586"
     password: !secret HUNTER_ap_wifi_key
 
+status_led:
+  pin:
+    number: D4
+    inverted: true
+
 #captive_portal:
 
 logger:


### PR DESCRIPTION
I had my ESP32 die and not having the status LED made it much more annoying to figure out if it was really dead or just having issues connecting to WiFi.

For the replacement I enabled the status LED and it works quite well.

I think it's a good default as it is easier for someone that doesn't like the LED to find it in the configuration and delete it, than for someone that would like to have the LED to remember to configure it and also figure out how to do so.